### PR TITLE
feat(devops): 🚀 initial Docker and release setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,45 @@
+# This file excludes paths from the Docker build context.
+#
+# By default, Docker's build context includes all files (and folders) in the
+# current directory. Even if a file isn't copied into the container it is still sent to
+# the Docker daemon.
+#
+# There are multiple reasons to exclude files from the build context:
+#
+# 1. Prevent nested folders from being copied into the container (ex: exclude
+#    /assets/node_modules when copying /assets)
+# 2. Reduce the size of the build context and improve build time (ex. /build, /deps, /doc)
+# 3. Avoid sending files containing sensitive information
+#
+# More information on using .dockerignore is available here:
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+.dockerignore
+
+# Ignore git, but keep git HEAD and refs to access current commit hash if needed:
+#
+# $ cat .git/HEAD | awk '{print ".git/"$2}' | xargs cat
+# d0b8727759e1e0e7aa3d41707d12376e373d5ecc
+.git
+!.git/HEAD
+!.git/refs
+
+# Common development/test artifacts
+/cover/
+/doc/
+/test/
+/tmp/
+.elixir_ls
+
+# Mix artifacts
+/_build/
+/deps/
+*.ez
+
+# Generated on crash by the VM
+erl_crash.dump
+
+# Static artifacts - These should be fetched and built inside the Docker image
+/assets/node_modules/
+/priv/static/assets/
+/priv/static/cache_manifest.json

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@ dependable-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
+
+/.fetch
+*.beam
+/config/*.secret.exs
+.elixir_ls/
+.env

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,3 @@
+elixir 1.18.4-otp-27
+erlang 27.3
+nodejs 24.3.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,91 @@
+ARG ELIXIR_VERSION=1.18.4
+ARG OTP_VERSION=27.3
+ARG ALPINE_VERSION=3.21.3
+ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-alpine-${ALPINE_VERSION}"
+ARG RUNNER_IMAGE="alpine:${ALPINE_VERSION}"
+
+FROM ${BUILDER_IMAGE} AS builder
+
+RUN apk -U upgrade && apk --no-cache add \
+  ca-certificates \
+  git \
+  make \
+  automake \
+  autoconf \
+  musl \
+  build-base \
+  curl \
+  openssl \
+  ncurses-libs \
+  libc-dev \
+  libstdc++ \
+  inotify-tools \
+  postgresql-client \
+  neovim bash \
+  && update-ca-certificates --fresh
+
+ARG MIX_ENV
+ARG API_PORT
+ARG EPMD_PORT
+ARG DIST_ERL_PORT_RANGE
+ARG APP_NAME
+ARG APP_VERSION
+ARG SHA
+
+ENV MIX_ENV=${MIX_ENV:-prod}
+ENV API_PORT=${API_PORT:-4000}
+ENV EPMD_PORT=${EPMD_PORT:-4369}
+ENV DIST_ERL_PORT_RANGE=${DIST_ERL_PORT_RANGE:-9100-9114}
+ENV APP_NAME=${APP_NAME:-my_app}
+ENV APP_VERSION=${APP_VERSION:-0.1.0}
+ENV SHA=${SHA:-missing-sha}
+
+COPY mix.exs mix.lock ./
+COPY  config/config.exs config/runtime.exs config/${MIX_ENV}.exs config/
+COPY lib lib
+COPY rel rel
+
+RUN mix local.rebar --force && mix local.hex --force
+RUN mix archive.install hex phx_new --force
+RUN mix deps.get --only $MIX_ENV
+RUN mix deps.compile
+RUN mix compile
+RUN mix release
+
+EXPOSE ${API_PORT}
+EXPOSE ${EPMD_PORT}
+EXPOSE ${DIST_ERL_PORT_RANGE}
+
+FROM ${RUNNER_IMAGE} AS runner
+
+RUN apk add --no-cache libstdc++ openssl ncurses-libs
+
+ARG MIX_ENV
+ARG API_PORT
+ARG EPMD_PORT
+ARG DIST_ERL_PORT_RANGE
+ARG APP_NAME
+ARG APP_VERSION
+ARG SHA
+
+LABEL org.opencontainers.image.version="${APP_VERSION}" \
+      org.opencontainers.image.revision="${SHA}" \
+      org.opencontainers.image.title="${APP_NAME}"
+
+ENV TZ="America/Sao_Paulo"
+ENV MIX_ENV=${MIX_ENV:-prod}
+ENV API_PORT=${API_PORT:-4000}
+ENV EPMD_PORT=${EPMD_PORT:-4369}
+ENV DIST_ERL_PORT_RANGE=${DIST_ERL_PORT_RANGE:-9100-9114}
+ENV APP_NAME=${APP_NAME:-my_app}
+ENV APP_VERSION=${APP_VERSION:-0.1.0}
+ENV SHA=${SHA:-missing-sha}
+
+EXPOSE ${EPMD_PORT}
+EXPOSE ${DIST_ERL_PORT_RANGE}
+
+COPY --from=builder --chown=nobody:nogroup _build/${MIX_ENV}/rel/${APP_NAME} .
+
+USER nobody:nogroup
+
+CMD ["/bin/server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+services:
+  db:
+    image: 'postgres:13.0-alpine' 
+    container_name: db
+    restart: always
+    environment:
+      POSTGRES_HOST: db
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: dependable
+      PGDATA: /tmp
+    hostname: db
+    ports:
+      - ":5432"
+    networks:
+      - dependable
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - './docker/postgres/data:/var/lib/postgresql/data'
+      
+  dependable:
+    build: 
+      context: .
+      target: builder
+      dockerfile: Dockerfile 
+      args: 
+        MIX_ENV: dev
+        APP_NAME: dependable
+    image: dependable:dev
+    volumes: 
+      - .:/app
+    command: mix run --no-halt
+    container_name: dependable
+    hostname: dependable
+    depends_on:
+      - db
+    deploy:
+      resources:
+        limits:
+          memory: 6g
+          cpus: "6"
+        reservations:
+          memory: 3g  
+          cpus: "3"
+    networks:
+      - dependable
+
+networks:
+  dependable:
+    driver: bridge

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -1,0 +1,7 @@
+HOSTNAME=$(hostname)
+
+export REPLACE_OS_VARS=true
+export RELEASE_DISTRIBUTION=name
+export RELEASE_NAME="<%= @release.name %>"
+export RELEASE_NODE="${RELEASE_NAME}@${HOSTNAME}"
+export RELEASE_COOKIE="${RELEASE_COOKIE}"

--- a/rel/overlays/bin/server
+++ b/rel/overlays/bin/server
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+cd -P -- "$(dirname -- "$0")"
+PHX_SERVER=true exec ./dependable start


### PR DESCRIPTION
These changes follow best practices for reproducible builds, clean release environments, and developer-friendly workflows.

- A multi-stage Dockerfile to build and run the Elixir release efficiently
- A docker-compose.yml file to simplify local development and service orchestration
- An env.sh.eex script that dynamically sets RELEASE_NODE using the container hostname
- A .dockerignore to avoid copying unnecessary files to the image
- A .tool-versions file for consistent local Elixir/Erlang versions across environments
- An updated .gitignore to exclude build artifacts and Docker-related files
- A custom rel/overlays/bin/server script to start the release inside the container